### PR TITLE
Add phishing detector demo with front-end

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # 7702pd-wallet
-phishing-detect
+
+This is a minimal demo of an address and domain phishing detector inspired by
+[EIP-7702](https://eips.ethereum.org/EIPS/eip-7702). It loads a local blacklist
+based on the MetaMask phishing detector, exposes a simple API, and provides a
+basic web interface for testing addresses or domains.
+
+## Getting Started
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Run the server:
+
+```bash
+npm start
+```
+
+Open `http://localhost:3000` in a browser and enter an address or domain to see
+a security score. The server also exposes `/api/ephemeral` which returns a
+random ephemeral address generated via `ethers`.
+
+> **Note:** The blacklist and third-party API integration are illustrative and
+> contain only sample data. For full functionality you should download the
+> official MetaMask blacklist and configure a real API endpoint.

--- a/eth-phishing-config.json
+++ b/eth-phishing-config.json
@@ -1,0 +1,10 @@
+{
+  "blacklist": [
+    "examplebad.com",
+    "phishingsite.io"
+  ],
+  "addressBlacklist": [
+    "0x1234567890abcdef1234567890abcdef12345678",
+    "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>7702 Phishing Detector</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 40px; }
+    #result { margin-top: 20px; }
+  </style>
+</head>
+<body>
+  <h1>7702 Phishing Detector</h1>
+  <p>Enter an Ethereum address or domain to evaluate.</p>
+  <input id="input" type="text" placeholder="0x... or domain" size="40">
+  <button onclick="check()">Check</button>
+  <pre id="result"></pre>
+
+<script>
+async function check() {
+  const value = document.getElementById('input').value.trim();
+  if (!value) return;
+  const res = await fetch('/api/check', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ value })
+  });
+  const data = await res.json();
+  document.getElementById('result').textContent =
+    `Score: ${data.score}\nReasons: ${data.reasons.join(', ')}`;
+}
+</script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "7702pd-wallet",
+  "version": "1.0.0",
+  "description": "Simple phishing detection demo integrating EIP-7702",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "ethers": "^6.12.0",
+    "node-fetch": "^3.3.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,68 @@
+const express = require('express');
+const fs = require('fs');
+const fetch = require('node-fetch');
+const { Wallet } = require('ethers');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+// Load local phishing config
+const config = JSON.parse(fs.readFileSync('./eth-phishing-config.json'));
+
+// Simple ephemeral wallet generator using ethers (EIP-7702 style stub)
+function createEphemeralWallet() {
+  return Wallet.createRandom();
+}
+
+// Placeholder third-party blacklist check (stub, no network in this environment)
+async function checkThirdParty(value) {
+  // In a real environment, call the third-party API here
+  // Return true if the value is blacklisted
+  return false;
+}
+
+// Basic scoring logic
+async function evaluate(value) {
+  const lower = value.toLowerCase();
+  let score = 100;
+  let reasons = [];
+
+  if (lower.startsWith('0x') && lower.length === 42) {
+    if (config.addressBlacklist.includes(lower)) {
+      score -= 70;
+      reasons.push('Listed in local address blacklist');
+    }
+  } else {
+    if (config.blacklist.includes(lower)) {
+      score -= 70;
+      reasons.push('Listed in local domain blacklist');
+    }
+  }
+
+  if (await checkThirdParty(lower)) {
+    score -= 20;
+    reasons.push('Listed by third-party blacklist');
+  }
+
+  if (score < 0) score = 0;
+  return { score, reasons };
+}
+
+app.use(express.static('.'));
+app.use(express.json());
+
+app.post('/api/check', async (req, res) => {
+  const { value } = req.body;
+  if (!value) return res.status(400).json({ error: 'Missing value' });
+  const result = await evaluate(value);
+  res.json(result);
+});
+
+app.get('/api/ephemeral', (req, res) => {
+  const wallet = createEphemeralWallet();
+  res.json({ address: wallet.address });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- implement simple Node/Express server with EIP‑7702 styled ephemeral wallet stub
- add local blacklist data and evaluation logic
- provide a small web interface to test addresses or domains
- document setup in README

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685eaae31d18832db4e866b296e50a55